### PR TITLE
Pull in socket unit from systemd service

### DIFF
--- a/yubikey-touch-detector.service
+++ b/yubikey-touch-detector.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Detects when your YubiKey is waiting for a touch
+Requires=yubikey-touch-detector.socket
 
 [Service]
 ExecStart=/usr/bin/yubikey-touch-detector
 EnvironmentFile=-%E/yubikey-touch-detector/service.conf
 
 [Install]
+Also=yubikey-touch-detector.socket
 WantedBy=default.target


### PR DESCRIPTION
If the service doesn't pull in the socket unit, the latter will become unusable until the service exits again.  This way, behavior is consistent no matter if socket activation happened or the service was started manually/automatically.

Additionally, whether you want socket activation or automatic start-up, you won't get errors from systemd trying to switch between the configurations.