### PR TITLE
Use native D-Bus and libnotify implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.16
 
 require (
 	github.com/coreos/go-systemd/v22 v22.3.2
-	github.com/menefotto/go-libnotify v0.0.0-20160821232856-351dc16572b9
+	github.com/esiqveland/notify v0.11.0
+	github.com/godbus/dbus/v5 v5.0.4
 	github.com/rjeczalik/notify v0.9.2
 	github.com/scylladb/go-set v1.0.2
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -3,11 +3,13 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/esiqveland/notify v0.11.0 h1:0WJ/xW+3Ln8uRBYntG7f0XihXxnlOaQTdha1yyzXz30=
+github.com/esiqveland/notify v0.11.0/go.mod h1:63UbVSaeJwF0LVJARHFuPgUAoM7o1BEvCZyknsuonBc=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
-github.com/menefotto/go-libnotify v0.0.0-20160821232856-351dc16572b9 h1:rT1Icv4lVUyxLfZbs4SptWweIkEZSoYsrMCBjhUjUnk=
-github.com/menefotto/go-libnotify v0.0.0-20160821232856-351dc16572b9/go.mod h1:KdXlwZrg/gkgHuk2b2zSfkabln9xiNgG/GlRhDcFzWE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/notifier/unix_socket.go
+++ b/notifier/unix_socket.go
@@ -88,11 +88,11 @@ func SetupUnixSocketNotifier(notifiers *sync.Map, exits *sync.Map) {
 			return
 		}
 
-		go notify(listener, touchListeners, &touchListenersMutex)
+		go unixSocketNotify(listener, touchListeners, &touchListenersMutex)
 	}
 }
 
-func notify(listener net.Conn, touchListeners map[*net.Conn]chan []byte, touchListenersMutex *sync.RWMutex) {
+func unixSocketNotify(listener net.Conn, touchListeners map[*net.Conn]chan []byte, touchListenersMutex *sync.RWMutex) {
 	values := make(chan []byte)
 	touchListenersMutex.Lock()
 	touchListeners[&listener] = values


### PR DESCRIPTION
This change makes the libnotify-compatible notifications more resilient by switching to a different library that uses a native implementation of the D-Bus protocol.

The prior implementation of the notifications code reserved a single notification identifier when the program started; however, some notification daemons (like mate-notification-daemon) automatically terminate after some period of notification inactivity. They are reactivated by writing new notifications via D-Bus. In this case, the generated ID would no longer make sense to the newly activated process, and show the notification would fail.

With the help of the new library, this change keeps track of the notification ID and only reserves it while the notification is actually being shown.