### PR TITLE
fix: detect yubikey touches for the new gpg version

### DIFF
--- a/detector/gpg.go
+++ b/detector/gpg.go
@@ -13,16 +13,16 @@ import (
 
 // WatchGPG watches for hints that YubiKey is maybe waiting for a touch on a GPG request
 func WatchGPG(filesToWatch []string, requestGPGCheck chan bool) {
-	events := make(chan notify.EventInfo, len(filesToWatch))
+	events := make(chan notify.EventInfo)
 
 	initWatcher := func() {
-	  for _, file := range filesToWatch {
-	  	if err := notify.Watch(file, events, notify.InOpen); err != nil {
-	  		log.Errorf("Failed to watch file '%s': %v\n", file, err)
-	  		return;
-	  	}
-	  	log.Debug("GPG watcher is watching '%s'...\n", file)
-	  }
+		for _, file := range filesToWatch {
+			if err := notify.Watch(file, events, notify.InOpen, notify.InDeleteSelf, notify.InMoveSelf); err != nil {
+				log.Errorf("Failed to watch file '%s': %v\n", file, err)
+				return
+			}
+			log.Debugf("GPG watcher is watching '%s'...\n", file)
+		}
 	}
 
 	initWatcher()

--- a/detector/gpg.go
+++ b/detector/gpg.go
@@ -13,12 +13,14 @@ import (
 
 // WatchGPG watches for hints that YubiKey is maybe waiting for a touch on a GPG request
 func WatchGPG(filesToWatch []string, requestGPGCheck chan bool) {
+	// No need for a buffered channel,
+	// we are interested only in the first event, it's ok to skip all subsequent ones
 	events := make(chan notify.EventInfo)
 
 	initWatcher := func() {
 		for _, file := range filesToWatch {
 			if err := notify.Watch(file, events, notify.InOpen, notify.InDeleteSelf, notify.InMoveSelf); err != nil {
-				log.Errorf("Failed to watch file '%s': %v\n", file, err)
+				log.Errorf("Failed to establish a watch on GPG file '%s': %v\n", file, err)
 				return
 			}
 			log.Debugf("GPG watcher is watching '%s'...\n", file)

--- a/main.go
+++ b/main.go
@@ -84,15 +84,13 @@ func main() {
 			log.Debugf("Directory '%s' does not exist (you have no private keys).\n", gpgPrivateKeysDirPath)
 			return
 		}
-		searchTerm := "shadowed-private-key"
-		var filesToWatch []string
-		filesToWatch, err := findShadowedPrivateKeys(gpgPrivateKeysDirPath, searchTerm)
+		filesToWatch, err := findShadowedPrivateKeys(gpgPrivateKeysDirPath)
 		if err != nil {
-			fmt.Printf("Error finding files: %v\n", err)
+			log.Debugf("Error finding shadowed private keys: %v\n", err)
 			return
 		}
 		if len(filesToWatch) == 0 {
-			fmt.Printf("No files matching the term '%s' found.\n", searchTerm)
+			log.Debugf("No shadowed private keys found.\n")
 			return
 		}
 		requestGPGCheck := make(chan bool)
@@ -104,9 +102,9 @@ func main() {
 	<-wait
 }
 
-func findShadowedPrivateKeys(folderPath, term string) ([]string, error) {
+func findShadowedPrivateKeys(folderPath string) ([]string, error) {
 	var result []string
-	err := filepath.Walk(folderPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(folderPath, func(path string, info os.DirEntry, err error) error {
 		if err != nil || info.IsDir() {
 			return err
 		}
@@ -114,7 +112,7 @@ func findShadowedPrivateKeys(folderPath, term string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		if strings.Contains(string(data), term) {
+		if strings.Contains(string(data), "shadowed-private-key") {
 			result = append(result, path)
 		}
 		return nil

--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func main() {
 		log.Debugf("Cannot initialize Assuan IPC: %v. Disabling GPG and SSH watchers.", err)
 	} else {
 		var gpgPrivateKeysDirPath = path.Join(gpgme.GetDirInfo("homedir"), "private-keys-v1.d")
-		if _, err := os.Stat(gpgPrivateKeysDirPath); os.IsNotExist(err) {
-			log.Debugf("Directory '%s' does not exist (you have no private keys).\n", gpgPrivateKeysDirPath)
+		if _, err := os.Stat(gpgPrivateKeysDirPath); err != nil {
+			log.Debugf("Directory '%s' does not exist or cannot stat it\n", gpgPrivateKeysDirPath)
 			return
 		}
 		filesToWatch, err := findShadowedPrivateKeys(gpgPrivateKeysDirPath)


### PR DESCRIPTION
The new detection heuristic now checks whether the private key files are opened.

We specifically detect private keys that require a YubiKey touch by filtering out those that have the shadowed-private-key attribute in the S-expression inside the .key file. For more details, refer to the [gnupg documentation that talks about .key format](https://github.com/gpg/gnupg/blob/6737e07a9b04064947ae37abd28b845a09abee22/doc/keyformat.txt#shadowed-private-key-format).

There may be false positives if the user has both a YubiKey and another GPG smartcard device, as the heuristic will detect that gpg opens a private key file. However, this approach is a significant improvement over the current situation, where no devices are detected.

I should mention that I am not an expert in Go (I read just enough to implement this pull request). I originally prototyped this idea in Python and then ported it to Go. Therefore, any feedback on the code would be greatly appreciated, especially if there are any issues with structure or potential bad practices. Let me know if refactoring is needed!

This closes #54 