### PR TITLE
git: ignore nix env folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 yubikey-touch-detector
 dist
 vendor
+.direnv
+result


### PR DESCRIPTION
While working on another pull request, I found it frustrating that Git was tracking the .direnv and result/ folders (where Nix saves the program's closure). 

This pull request adds these folders to the .gitignore to prevent them from being tracked.