### PR TITLE
add dbus notifier - support notifications via dbus SessionBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The app supports the following environment variables and CLI arguments (CLI args
 | `YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY` | `--libnotify` |
 | `YUBIKEY_TOUCH_DETECTOR_STDOUT`    | `--stdout`    |
 | `YUBIKEY_TOUCH_DETECTOR_NOSOCKET`  | `--no-socket` |
+| `YUBIKEY_TOUCH_DETECTOR_DBUS`      | `--dbus`      |
 
 You can configure the systemd service by defining any of these environment variables in `$XDG_CONFIG_HOME/yubikey-touch-detector/service.conf` - see `service.conf.example` for a configuration example.
 
@@ -107,6 +108,12 @@ Next, in order to integrate the app with other UI components to display a visibl
 | `MAC_0` | when a `hmac` operation stopped waiting for a touch |
 
 All messages have a fixed length of 5 bytes to simplify the code on the receiving side.
+
+##### notifier/dbus
+
+`dbus` notifier registers a dbus server at the interface name `com.github.maximbaz.YubikeyTouchDetector` and path `/com/github/maximbaz/YubikeyTouchDetector`.
+
+Properties on this dbus interface are discoverable through introspection. Properties also emit PropertiesChanged signals to indicate updates and support gobject binding.
 
 ## How it works
 

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
             # remember to bump this hash when your dependencies change.
             # vendorHash = pkgs.lib.fakeHash;
 
-            vendorHash = "sha256-x8Fmhsk6MtgAtLxgH/V3KusM0BXAOaSU+2HULR5boJQ=";
+            vendorHash = "sha256-oHEcpu3QvcVC/YCtGtP7nNT9++BSU8BPT5pf8NdLrOo=";
 
             nativeBuildInputs = with pkgs; [ pkg-config scdoc ];
 

--- a/main.go
+++ b/main.go
@@ -28,18 +28,21 @@ func main() {
 	envLibnotify := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY"))]
 	envStdout := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_STDOUT"))]
 	envNosocket := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_NOSOCKET"))]
+	envDbus := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_DBUS"))]
 
 	var version bool
 	var verbose bool
 	var libnotify bool
 	var stdout bool
 	var nosocket bool
+	var dbus bool
 
 	flag.BoolVar(&version, "version", false, "print version and exit")
 	flag.BoolVar(&verbose, "v", envVerbose, "enable debug logging")
 	flag.BoolVar(&libnotify, "libnotify", envLibnotify, "show desktop notifications using libnotify")
 	flag.BoolVar(&stdout, "stdout", envStdout, "print notifications to stdout")
 	flag.BoolVar(&nosocket, "no-socket", envNosocket, "disable unix socket notifier")
+	flag.BoolVar(&dbus, "dbus", envDbus, "enable dbus server for IPC")
 	flag.Parse()
 
 	if version {
@@ -70,6 +73,9 @@ func main() {
 	}
 	if stdout {
 		go notifier.SetupStdoutNotifier(notifiers)
+	}
+	if dbus {
+		go notifier.SetupDbusNotifier(notifiers)
 	}
 
 	go detector.WatchU2F(notifiers)

--- a/notifier/dbus.go
+++ b/notifier/dbus.go
@@ -1,0 +1,131 @@
+package notifier
+
+import (
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/godbus/dbus/v5/prop"
+	log "github.com/sirupsen/logrus"
+)
+
+const DBUS_IFACE string = "com.github.maximbaz.YubikeyTouchDetector"
+const DBUS_PATH dbus.ObjectPath = "/com/github/maximbaz/YubikeyTouchDetector"
+
+const PROP_GPG_STATE string = "GPGState"
+const PROP_U2F_STATE string = "U2FState"
+const PROP_HMAC_STATE string = "HMACState"
+
+var messagePropMap = map[Message]string{
+	GPG_ON:   PROP_GPG_STATE,
+	GPG_OFF:  PROP_GPG_STATE,
+	U2F_ON:   PROP_U2F_STATE,
+	U2F_OFF:  PROP_U2F_STATE,
+	HMAC_ON:  PROP_HMAC_STATE,
+	HMAC_OFF: PROP_HMAC_STATE,
+}
+
+var messageValueMap = map[Message]dbus.Variant{
+	GPG_ON:   dbus.MakeVariant(uint32(1)),
+	GPG_OFF:  dbus.MakeVariant(uint32(0)),
+	U2F_ON:   dbus.MakeVariant(uint32(1)),
+	U2F_OFF:  dbus.MakeVariant(uint32(0)),
+	HMAC_ON:  dbus.MakeVariant(uint32(1)),
+	HMAC_OFF: dbus.MakeVariant(uint32(0)),
+}
+
+type server struct{}
+
+func SetupDbusNotifier(notifiers *sync.Map) {
+	conn, err := dbus.ConnectSessionBus()
+	if err != nil {
+		log.Error("Cannot establish dbus SessionBus connection ", err)
+		return
+	}
+	defer conn.Close()
+
+	reply, err := conn.RequestName(DBUS_IFACE,
+		dbus.NameFlagDoNotQueue)
+	if err != nil {
+		log.Error("Cannot request dbus interface name ", err)
+		return
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		log.Error("dbus interface name already taken")
+		return
+	}
+
+	propsSpec := map[string]map[string]*prop.Prop{
+		DBUS_IFACE: {
+			PROP_GPG_STATE: {
+				Value:    uint32(0),
+				Writable: true,
+				Emit:     prop.EmitTrue,
+				Callback: func(c *prop.Change) *dbus.Error {
+					log.Debug(DBUS_IFACE, ".", c.Name, " changed to ", c.Value)
+					return nil
+				},
+			},
+			PROP_U2F_STATE: {
+				Value:    uint32(0),
+				Writable: true,
+				Emit:     prop.EmitTrue,
+				Callback: func(c *prop.Change) *dbus.Error {
+					log.Debug(DBUS_IFACE, ".", c.Name, " changed to ", c.Value)
+					return nil
+				},
+			},
+			PROP_HMAC_STATE: {
+				Value:    uint32(0),
+				Writable: true,
+				Emit:     prop.EmitTrue,
+				Callback: func(c *prop.Change) *dbus.Error {
+					log.Debug(DBUS_IFACE, ".", c.Name, " changed to ", c.Value)
+					return nil
+				},
+			},
+		},
+	}
+
+	s := server{}
+	err = conn.Export(s, DBUS_PATH, DBUS_IFACE)
+	if err != nil {
+		log.Error("dbus export server failed ", err)
+		return
+	}
+
+	props, err := prop.Export(conn, DBUS_PATH, propsSpec)
+	if err != nil {
+		log.Error("dbus export propSpec failed ", err)
+		return
+	}
+	n := &introspect.Node{
+		Name: string(DBUS_PATH),
+		Interfaces: []introspect.Interface{
+			introspect.IntrospectData,
+			prop.IntrospectData,
+			{
+				Name:       DBUS_IFACE,
+				Methods:    introspect.Methods(s),
+				Properties: props.Introspection(DBUS_IFACE),
+			},
+		},
+	}
+	err = conn.Export(introspect.NewIntrospectable(n), DBUS_PATH, "org.freedesktop.DBus.Introspectable")
+	if err != nil {
+		log.Error("dbus export introspect failed ", err)
+		return
+	}
+	log.Debug("Connected to dbus session interface ", DBUS_IFACE)
+
+	touch := make(chan Message, 10)
+	notifiers.Store("notifier/dbus", touch)
+
+	for {
+		message := <-touch
+		err := props.Set(DBUS_IFACE, messagePropMap[message], messageValueMap[message])
+		if err != nil {
+			log.Warn("dbus failed to update property ", messagePropMap[message], ", ", err)
+		}
+	}
+}


### PR DESCRIPTION
Hey! Love the service. I've already been using it with libnotify, and am about to incorporate it into an on screen display. Thought it would be nice to get states directly by via dbus.

Dashes aren't valid in dbus paths, so I opted for `YubikeyTouchDetector`.

Happy to make changes if you have any other thoughts on the interface. It could also just emit signals directly instead of updating properties and relying on dbus PropertiesChanged signals.