### PR TITLE
feat: include trigger context in notification

### DIFF
--- a/PROCESS-CONTEXT.md
+++ b/PROCESS-CONTEXT.md
@@ -1,0 +1,74 @@
+# Process context in notifications
+
+When YubiKey touch detector fires a notification, it attempts to identify *which
+process* triggered the touch request and includes that information in the
+notification body.  This helps you verify that a legitimate operation is
+requesting the touch, rather than a rogue program.
+
+## How it works per operation type
+
+### GPG / SSH agent
+
+GPG operations go through `gpg-agent`, which accepts connections over a Unix
+domain socket.  To find the caller, the detector:
+
+1. Runs `ss -xpn` to obtain a table of all connected Unix socket pairs, indexed
+   by their kernel-assigned inode numbers.
+2. Scans `/proc` to find the `gpg-agent` process(es) and records the inode of
+   every socket file descriptor they hold open.
+3. For each of those inodes, follows the peer-inode link from step 1 to find
+   the *other* process that is connected to `gpg-agent` at this moment.
+4. Reads `/proc/<pid>/cmdline` for that process to obtain its full command line.
+
+Background daemons that are permanently connected to `gpg-agent` (currently
+`gpg-agent` itself and `scdaemon`) are filtered out.  All remaining callers are
+reported, one per line, in the notification body.
+
+**Example notification body:**
+
+```
+git commit -S -m "my commit message"
+```
+
+or, if multiple callers are active simultaneously:
+
+```
+git commit -S -m "sign release"
+ansible-playbook site.yml
+```
+
+#### SSH agent forwarding
+
+When the SSH detector intercepts traffic destined for `gpg-agent` acting as an
+SSH agent, it identifies the peer process on the intercepted socket connection
+directly via `SO_PEERCRED` (a single syscall that returns the connecting
+process's PID without any `/proc` scanning).
+
+### U2F / FIDO2 and PIV / HMAC-SHA1
+
+These operations are triggered by direct device access rather than through a
+socket-based agent, so no process-identification is performed.  The notification
+body will be empty for these cases.
+
+## Notification behaviour
+
+| State | Summary | Body | Timeout |
+|---|---|---|---|
+| Waiting for touch | "YubiKey is waiting for a touch" | Caller command line(s) | Persistent — stays until touched |
+| Operation just completed | "YubiKey was in use" | Caller command line(s) | Auto-dismisses after 5 seconds |
+
+The notification deliberately stays visible after the touch is accepted so you
+have time to read which process triggered the operation.
+
+## Limitations and caveats
+
+- The `/proc` scan and `ss` invocation happen at the moment the GPG file-open
+  event is detected, which is slightly *before* the card actually prompts for a
+  touch.  In rare race conditions a very short-lived caller may already have
+  exited before the scan runs, and no context will be shown.
+- Only processes running as the same user (or root) can be inspected via
+  `/proc/<pid>/fd`.  Cross-user scenarios (e.g. sudo gpg) may not surface the
+  outer caller.
+- The command line shown is the full `argv` of the direct caller.  If the
+  operation was initiated by a shell script or a wrapper, the intermediate
+  process name is shown, not the human who typed the command.

--- a/detector/context.go
+++ b/detector/context.go
@@ -1,0 +1,93 @@
+package detector
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// getProcessCmdline returns the command line of a process given its PID,
+// with NUL separators replaced by spaces.
+func getProcessCmdline(pid int32) string {
+	if pid <= 0 {
+		return ""
+	}
+	cmdlineBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil || len(cmdlineBytes) == 0 {
+		return ""
+	}
+	cmdline := strings.TrimRight(string(cmdlineBytes), "\x00")
+	return strings.Join(strings.Split(cmdline, "\x00"), " ")
+}
+
+// getPeerProcessCmdline returns the command line of the process on the other
+// end of a Unix socket connection, using SO_PEERCRED.
+func getPeerProcessCmdline(conn net.Conn) string {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return ""
+	}
+	raw, err := unixConn.SyscallConn()
+	if err != nil {
+		return ""
+	}
+	var pid int32
+	_ = raw.Control(func(fd uintptr) {
+		ucred, e := syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+		if e == nil {
+			pid = ucred.Pid
+		}
+	})
+	return getProcessCmdline(pid)
+}
+
+// gpgContextCandidates lists program names (matched against argv[0] basename)
+// that are likely to be the user-facing process triggering a GPG/SSH operation.
+var gpgContextCandidates = []string{
+	"gpg", "gpg2", "pass", "git", "ssh", "ansible", "ansible-playbook",
+}
+
+// gpgContextExcluded lists background daemons that should not be reported
+// as the triggering process.
+var gpgContextExcluded = map[string]bool{
+	"gpg-agent": true,
+	"scdaemon":  true,
+}
+
+// findGPGContext scans /proc for a likely user-facing process that triggered
+// a GPG or SSH operation.  This is best-effort: a concurrent unrelated process
+// with a matching name may be returned instead.
+func findGPGContext() string {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return ""
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		cmdlineBytes, err := os.ReadFile(fmt.Sprintf("/proc/%s/cmdline", entry.Name()))
+		if err != nil || len(cmdlineBytes) == 0 {
+			continue
+		}
+		cmdline := strings.TrimRight(string(cmdlineBytes), "\x00")
+		fields := strings.Split(cmdline, "\x00")
+		progName := path.Base(fields[0])
+		if gpgContextExcluded[progName] {
+			continue
+		}
+		for _, cand := range gpgContextCandidates {
+			if progName == cand {
+				return strings.Join(fields, " ")
+			}
+		}
+	}
+	return ""
+}

--- a/detector/context.go
+++ b/detector/context.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // getProcessCmdline returns the command line of a process given its PID,
@@ -30,10 +32,12 @@ func getProcessCmdline(pid int32) string {
 func getPeerProcessCmdline(conn net.Conn) string {
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
+		log.Debug("getPeerProcessCmdline: connection is not a UnixConn")
 		return ""
 	}
 	raw, err := unixConn.SyscallConn()
 	if err != nil {
+		log.Debugf("getPeerProcessCmdline: SyscallConn error: %v", err)
 		return ""
 	}
 	var pid int32
@@ -41,9 +45,14 @@ func getPeerProcessCmdline(conn net.Conn) string {
 		ucred, e := syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 		if e == nil {
 			pid = ucred.Pid
+		} else {
+			log.Debugf("getPeerProcessCmdline: GetsockoptUcred error: %v", e)
 		}
 	})
-	return getProcessCmdline(pid)
+	log.Debugf("getPeerProcessCmdline: peer pid=%d", pid)
+	result := getProcessCmdline(pid)
+	log.Debugf("getPeerProcessCmdline: result=%q", result)
+	return result
 }
 
 // gpgContextExcluded lists background daemons that should not be reported
@@ -53,22 +62,30 @@ var gpgContextExcluded = map[string]bool{
 	"scdaemon":  true,
 }
 
-// unixSocketPeerMap parses `ss -xpn` output to build a map from each Unix
-// socket's inode to its connected peer's inode.
+// ssSocketInfo holds per-socket data parsed from one line of `ss -xpn` output.
+type ssSocketInfo struct {
+	state     string // ESTAB, LISTEN, etc.
+	localAddr string // local socket path, or "" if unnamed ("*")
+	localIno  uint32
+	peerIno   uint32
+	pid       int32  // owning process PID from users field, 0 if not available
+	procName  string // owning process name from users field, "" if not available
+}
+
+// parseSSSockets runs `ss -xpn` and returns one record per socket endpoint.
 //
-// ss output format (one line per socket endpoint):
+// ss output format (one line per endpoint, whitespace-separated):
 //
-//	u_str ESTAB 0 0  <local-addr> <local-inode>  <peer-addr> <peer-inode>  [users:(...)]
+//	<type> <state> <recv-q> <send-q> <local-addr> <local-inode> <peer-addr> <peer-inode> [users:(...)]
 //
-// Both the local and peer inode appear at fixed field offsets (indices 5 and 7)
-// regardless of whether the address field is "*" or a socket path.
-func unixSocketPeerMap() (map[uint32]uint32, error) {
+// The optional users field: users:(("name",pid=NNN,fd=M),...)
+func parseSSSockets() ([]ssSocketInfo, error) {
 	out, err := exec.Command("ss", "-xpn", "--no-header").Output()
 	if err != nil {
 		return nil, fmt.Errorf("ss: %w", err)
 	}
 
-	result := make(map[uint32]uint32)
+	var sockets []ssSocketInfo
 	for _, line := range strings.Split(string(out), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 8 {
@@ -76,89 +93,187 @@ func unixSocketPeerMap() (map[uint32]uint32, error) {
 		}
 		localIno, err1 := strconv.ParseUint(fields[5], 10, 32)
 		peerIno, err2 := strconv.ParseUint(fields[7], 10, 32)
-		if err1 != nil || err2 != nil || localIno == 0 || peerIno == 0 {
+		if err1 != nil || err2 != nil || localIno == 0 {
 			continue
 		}
-		result[uint32(localIno)] = uint32(peerIno)
+		localAddr := fields[4]
+		if localAddr == "*" {
+			localAddr = ""
+		}
+		sock := ssSocketInfo{
+			state:     fields[1],
+			localAddr: localAddr,
+			localIno:  uint32(localIno),
+			peerIno:   uint32(peerIno),
+		}
+		// Parse optional users field: users:(("name",pid=NNN,fd=M),...)
+		for _, f := range fields[8:] {
+			if !strings.HasPrefix(f, "users:") {
+				continue
+			}
+			sock.procName = extractSSName(f)
+			sock.pid = extractSSPID(f)
+			break
+		}
+		sockets = append(sockets, sock)
+	}
+	return sockets, nil
+}
+
+// extractSSPID extracts the first pid value from a ss users field.
+func extractSSPID(users string) int32 {
+	idx := strings.Index(users, "pid=")
+	if idx < 0 {
+		return 0
+	}
+	rest := users[idx+4:]
+	end := strings.IndexAny(rest, ",)")
+	if end < 0 {
+		end = len(rest)
+	}
+	p, err := strconv.ParseInt(rest[:end], 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int32(p)
+}
+
+// extractSSName extracts the first process name from a ss users field.
+func extractSSName(users string) string {
+	// format: users:(("name",pid=NNN,fd=M),...)
+	start := strings.Index(users, `users:(("`)
+	if start < 0 {
+		return ""
+	}
+	rest := users[start+9:]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+// unixSocketPeerMap returns a map from each Unix socket's local inode to its
+// peer inode. Used by tests.
+func unixSocketPeerMap() (map[uint32]uint32, error) {
+	sockets, err := parseSSSockets()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[uint32]uint32, len(sockets))
+	for _, s := range sockets {
+		if s.peerIno != 0 {
+			result[s.localIno] = s.peerIno
+		}
 	}
 	return result, nil
 }
 
-// findGPGContext identifies all non-daemon processes currently connected to
-// gpg-agent by tracing Unix socket peer inodes.
-// Returns one command line per caller, joined by newlines; empty if none found.
+// gpgAgentSocketPaths returns the set of Unix socket paths that gpg-agent
+// listens on, queried via gpgconf.
+func gpgAgentSocketPaths() map[string]bool {
+	paths := map[string]bool{}
+	for _, dir := range []string{"agent-socket", "agent-ssh-socket", "agent-extra-socket", "agent-browser-socket"} {
+		out, err := exec.Command("gpgconf", "--list-dirs", dir).Output()
+		if err != nil {
+			continue
+		}
+		p := strings.TrimSpace(string(out))
+		if p != "" {
+			paths[p] = true
+		}
+	}
+	return paths
+}
+
+// findGPGContext identifies processes connected to gpg-agent via ss output.
+//
+// In ss output for Unix sockets, the SERVER side of each accepted connection
+// shows the socket file path as the LOCAL address (fields[4]), even though the
+// accepted socket is anonymous.  The CLIENT side shows local=* but has a
+// readable users field.  The algorithm:
+//
+//  1. Find ss records with state=ESTAB and local-addr matching a gpg-agent
+//     socket path → those are gpg-agent's accepted-socket inodes.
+//  2. For each, look up the peer inode (the client socket) via the peer map
+//     built from all ss records.
+//  3. Find the client's ss record by its local inode → read users field → PID.
+//  4. Read /proc/PID/cmdline for the full command line.
 func findGPGContext() string {
-	peerMap, err := unixSocketPeerMap()
-	if err != nil {
+	agentPaths := gpgAgentSocketPaths()
+	if len(agentPaths) == 0 {
+		log.Debug("findGPGContext: no gpg-agent socket paths found")
 		return ""
 	}
+	log.Debugf("findGPGContext: gpg-agent socket paths: %v", agentPaths)
 
-	// Single /proc scan: build inode→pid for every process, and record which
-	// socket inodes belong to gpg-agent.
-	inodeToPID := map[uint32]int32{}
+	sockets, err := parseSSSockets()
+	if err != nil {
+		log.Debugf("findGPGContext: parseSSSockets error: %v", err)
+		return ""
+	}
+	log.Debugf("findGPGContext: ss returned %d socket records", len(sockets))
+
+	// Build localIno → socket record for fast lookups.
+	byLocalIno := make(map[uint32]*ssSocketInfo, len(sockets))
+	for i := range sockets {
+		s := &sockets[i]
+		byLocalIno[s.localIno] = s
+	}
+
+	// Collect gpg-agent's accepted-socket inodes: ESTAB records whose local
+	// address is one of gpg-agent's socket paths.
 	gpgAgentInodes := map[uint32]bool{}
-
-	entries, err := os.ReadDir("/proc")
-	if err != nil {
-		return ""
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		pid, err := strconv.Atoi(entry.Name())
-		if err != nil {
-			continue
-		}
-
-		comm, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-		isGPGAgent := strings.TrimSpace(string(comm)) == "gpg-agent"
-
-		fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", pid))
-		if err != nil {
-			continue
-		}
-		for _, fd := range fds {
-			link, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%s", pid, fd.Name()))
-			if err != nil {
-				continue
-			}
-			var inode uint32
-			if _, err := fmt.Sscanf(link, "socket:[%d]", &inode); err != nil {
-				continue
-			}
-			inodeToPID[inode] = int32(pid)
-			if isGPGAgent {
-				gpgAgentInodes[inode] = true
-			}
+	for i := range sockets {
+		s := &sockets[i]
+		if s.state == "ESTAB" && agentPaths[s.localAddr] {
+			gpgAgentInodes[s.localIno] = true
+			log.Debugf("findGPGContext: gpg-agent accepted socket: localAddr=%q localIno=%d peerIno=%d", s.localAddr, s.localIno, s.peerIno)
 		}
 	}
+	log.Debugf("findGPGContext: gpg-agent has %d ESTAB sockets", len(gpgAgentInodes))
 
-	// For each of gpg-agent's sockets, look up the peer inode and find which
-	// process owns it.
 	var results []string
 	seen := map[int32]bool{}
-	for agentInode := range gpgAgentInodes {
-		peerInode, ok := peerMap[agentInode]
-		if !ok || peerInode == 0 {
+	for agentIno := range gpgAgentInodes {
+		agentSock := byLocalIno[agentIno]
+		clientIno := agentSock.peerIno
+		if clientIno == 0 {
 			continue
 		}
-		clientPID, ok := inodeToPID[peerInode]
-		if !ok || seen[clientPID] {
+		clientSock, ok := byLocalIno[clientIno]
+		if !ok {
+			log.Debugf("findGPGContext: client inode %d not in ss output", clientIno)
+			continue
+		}
+		clientPID := clientSock.pid
+		if clientPID == 0 {
+			log.Debugf("findGPGContext: client inode %d has no pid in ss output", clientIno)
+			continue
+		}
+		if seen[clientPID] {
 			continue
 		}
 		seen[clientPID] = true
-
+		if gpgContextExcluded[clientSock.procName] {
+			log.Debugf("findGPGContext: pid %d (%s) excluded", clientPID, clientSock.procName)
+			continue
+		}
 		cmdline := getProcessCmdline(clientPID)
 		if cmdline == "" {
+			log.Debugf("findGPGContext: pid %d has empty cmdline", clientPID)
 			continue
 		}
 		fields := strings.Fields(cmdline)
 		if gpgContextExcluded[path.Base(fields[0])] {
+			log.Debugf("findGPGContext: pid %d (%s) excluded by cmdline", clientPID, fields[0])
 			continue
 		}
+		log.Debugf("findGPGContext: caller pid=%d cmdline=%q", clientPID, cmdline)
 		results = append(results, cmdline)
 	}
 
-	return strings.Join(results, "\n")
+	result := strings.Join(results, "\n")
+	log.Debugf("findGPGContext: returning %q", result)
+	return result
 }

--- a/detector/context.go
+++ b/detector/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -45,23 +46,58 @@ func getPeerProcessCmdline(conn net.Conn) string {
 	return getProcessCmdline(pid)
 }
 
-// gpgContextCandidates lists program names (matched against argv[0] basename)
-// that are likely to be the user-facing process triggering a GPG/SSH operation.
-var gpgContextCandidates = []string{
-	"gpg", "gpg2", "pass", "git", "ssh", "ansible", "ansible-playbook",
-}
-
 // gpgContextExcluded lists background daemons that should not be reported
-// as the triggering process.
+// as the triggering process even when they are connected to gpg-agent.
 var gpgContextExcluded = map[string]bool{
 	"gpg-agent": true,
 	"scdaemon":  true,
 }
 
-// findGPGContext scans /proc for a likely user-facing process that triggered
-// a GPG or SSH operation.  This is best-effort: a concurrent unrelated process
-// with a matching name may be returned instead.
+// unixSocketPeerMap parses `ss -xpn` output to build a map from each Unix
+// socket's inode to its connected peer's inode.
+//
+// ss output format (one line per socket endpoint):
+//
+//	u_str ESTAB 0 0  <local-addr> <local-inode>  <peer-addr> <peer-inode>  [users:(...)]
+//
+// Both the local and peer inode appear at fixed field offsets (indices 5 and 7)
+// regardless of whether the address field is "*" or a socket path.
+func unixSocketPeerMap() (map[uint32]uint32, error) {
+	out, err := exec.Command("ss", "-xpn", "--no-header").Output()
+	if err != nil {
+		return nil, fmt.Errorf("ss: %w", err)
+	}
+
+	result := make(map[uint32]uint32)
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			continue
+		}
+		localIno, err1 := strconv.ParseUint(fields[5], 10, 32)
+		peerIno, err2 := strconv.ParseUint(fields[7], 10, 32)
+		if err1 != nil || err2 != nil || localIno == 0 || peerIno == 0 {
+			continue
+		}
+		result[uint32(localIno)] = uint32(peerIno)
+	}
+	return result, nil
+}
+
+// findGPGContext identifies all non-daemon processes currently connected to
+// gpg-agent by tracing Unix socket peer inodes.
+// Returns one command line per caller, joined by newlines; empty if none found.
 func findGPGContext() string {
+	peerMap, err := unixSocketPeerMap()
+	if err != nil {
+		return ""
+	}
+
+	// Single /proc scan: build inode→pid for every process, and record which
+	// socket inodes belong to gpg-agent.
+	inodeToPID := map[uint32]int32{}
+	gpgAgentInodes := map[uint32]bool{}
+
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
 		return ""
@@ -70,24 +106,59 @@ func findGPGContext() string {
 		if !entry.IsDir() {
 			continue
 		}
-		if _, err := strconv.Atoi(entry.Name()); err != nil {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
 			continue
 		}
-		cmdlineBytes, err := os.ReadFile(fmt.Sprintf("/proc/%s/cmdline", entry.Name()))
-		if err != nil || len(cmdlineBytes) == 0 {
+
+		comm, _ := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+		isGPGAgent := strings.TrimSpace(string(comm)) == "gpg-agent"
+
+		fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", pid))
+		if err != nil {
 			continue
 		}
-		cmdline := strings.TrimRight(string(cmdlineBytes), "\x00")
-		fields := strings.Split(cmdline, "\x00")
-		progName := path.Base(fields[0])
-		if gpgContextExcluded[progName] {
-			continue
-		}
-		for _, cand := range gpgContextCandidates {
-			if progName == cand {
-				return strings.Join(fields, " ")
+		for _, fd := range fds {
+			link, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%s", pid, fd.Name()))
+			if err != nil {
+				continue
+			}
+			var inode uint32
+			if _, err := fmt.Sscanf(link, "socket:[%d]", &inode); err != nil {
+				continue
+			}
+			inodeToPID[inode] = int32(pid)
+			if isGPGAgent {
+				gpgAgentInodes[inode] = true
 			}
 		}
 	}
-	return ""
+
+	// For each of gpg-agent's sockets, look up the peer inode and find which
+	// process owns it.
+	var results []string
+	seen := map[int32]bool{}
+	for agentInode := range gpgAgentInodes {
+		peerInode, ok := peerMap[agentInode]
+		if !ok || peerInode == 0 {
+			continue
+		}
+		clientPID, ok := inodeToPID[peerInode]
+		if !ok || seen[clientPID] {
+			continue
+		}
+		seen[clientPID] = true
+
+		cmdline := getProcessCmdline(clientPID)
+		if cmdline == "" {
+			continue
+		}
+		fields := strings.Fields(cmdline)
+		if gpgContextExcluded[path.Base(fields[0])] {
+			continue
+		}
+		results = append(results, cmdline)
+	}
+
+	return strings.Join(results, "\n")
 }

--- a/detector/context_test.go
+++ b/detector/context_test.go
@@ -1,0 +1,136 @@
+package detector
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGetProcessCmdline(t *testing.T) {
+	// Use our own PID — /proc/<pid>/cmdline is always available.
+	pid := int32(os.Getpid())
+	cmdline := getProcessCmdline(pid)
+	if cmdline == "" {
+		t.Fatal("expected non-empty cmdline for current process")
+	}
+	// The test binary name should appear somewhere in argv[0].
+	if !strings.Contains(cmdline, "context") && !strings.Contains(cmdline, "test") {
+		t.Errorf("unexpected cmdline %q — expected it to contain the test binary name", cmdline)
+	}
+}
+
+func TestGetProcessCmdline_InvalidPID(t *testing.T) {
+	if got := getProcessCmdline(0); got != "" {
+		t.Errorf("expected empty string for pid 0, got %q", got)
+	}
+	if got := getProcessCmdline(-1); got != "" {
+		t.Errorf("expected empty string for pid -1, got %q", got)
+	}
+	// PID 2^30 is extremely unlikely to exist.
+	if got := getProcessCmdline(1 << 30); got != "" {
+		t.Errorf("expected empty string for non-existent pid, got %q", got)
+	}
+}
+
+func TestGetPeerProcessCmdline(t *testing.T) {
+	// Set up a Unix socket pair so we can call getPeerProcessCmdline.
+	dir := t.TempDir()
+	socketPath := fmt.Sprintf("%s/test.sock", dir)
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal("listen:", err)
+	}
+	defer ln.Close()
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err == nil {
+			connCh <- c
+		}
+	}()
+
+	client, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatal("dial:", err)
+	}
+	defer client.Close()
+
+	server := <-connCh
+	defer server.Close()
+
+	// From the server side, the peer is this test process.
+	result := getPeerProcessCmdline(server)
+	if result == "" {
+		t.Fatal("expected non-empty peer cmdline")
+	}
+	if !strings.Contains(result, "context") && !strings.Contains(result, "test") {
+		t.Errorf("unexpected peer cmdline %q", result)
+	}
+}
+
+func TestGetPeerProcessCmdline_NonUnixConn(t *testing.T) {
+	// A TCP connection is not a Unix socket; should return "".
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept()
+		connCh <- c
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	server := <-connCh
+	defer server.Close()
+
+	if got := getPeerProcessCmdline(server); got != "" {
+		t.Errorf("expected empty string for TCP conn, got %q", got)
+	}
+}
+
+func TestFindGPGContext(t *testing.T) {
+	// findGPGContext scans /proc.  We cannot guarantee a GPG process is running,
+	// but we can verify it returns a string (possibly empty) without panicking.
+	result := findGPGContext()
+	// If the test binary itself matched a candidate name this would be non-empty,
+	// but "context.test" does not match any candidate — so we just check no panic.
+	_ = result
+}
+
+func TestFindGPGContext_ExcludesDaemons(t *testing.T) {
+	// Verify that gpgContextExcluded contains the expected daemon names.
+	for _, daemon := range []string{"gpg-agent", "scdaemon"} {
+		if !gpgContextExcluded[daemon] {
+			t.Errorf("expected %q to be in gpgContextExcluded", daemon)
+		}
+	}
+}
+
+func TestFindGPGContext_CandidateList(t *testing.T) {
+	// Verify that the candidate list contains the expected program names.
+	expected := []string{"gpg", "git", "ssh", "pass"}
+	for _, name := range expected {
+		found := false
+		for _, cand := range gpgContextCandidates {
+			if cand == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q to be in gpgContextCandidates", name)
+		}
+	}
+}

--- a/detector/context_test.go
+++ b/detector/context_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -100,37 +101,81 @@ func TestGetPeerProcessCmdline_NonUnixConn(t *testing.T) {
 	}
 }
 
+// socketInode returns the inode number of the underlying socket fd.
+func socketInode(t *testing.T, conn net.Conn) uint32 {
+	t.Helper()
+	raw, err := conn.(*net.UnixConn).SyscallConn()
+	if err != nil {
+		t.Fatal("SyscallConn:", err)
+	}
+	var inode uint32
+	_ = raw.Control(func(fd uintptr) {
+		var st syscall.Stat_t
+		if err := syscall.Fstat(int(fd), &st); err == nil {
+			inode = uint32(st.Ino)
+		}
+	})
+	if inode == 0 {
+		t.Fatal("could not determine socket inode")
+	}
+	return inode
+}
+
+func TestUnixSocketPeerMap(t *testing.T) {
+	// Create a connected Unix socket pair so we have a known pair to look for.
+	dir := t.TempDir()
+	ln, err := net.Listen("unix", dir+"/peer.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, _ := ln.Accept()
+		connCh <- c
+	}()
+
+	client, err := net.Dial("unix", dir+"/peer.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	server := <-connCh
+	defer server.Close()
+
+	clientInode := socketInode(t, client)
+	serverInode := socketInode(t, server)
+
+	peerMap, err := unixSocketPeerMap()
+	if err != nil {
+		t.Fatal("unixSocketPeerMap:", err)
+	}
+	if len(peerMap) == 0 {
+		t.Fatal("expected non-empty peer map")
+	}
+
+	// Both ends of our socket pair must appear in the map and point at each other.
+	if got := peerMap[clientInode]; got != serverInode {
+		t.Errorf("peerMap[client inode %d] = %d, want %d", clientInode, got, serverInode)
+	}
+	if got := peerMap[serverInode]; got != clientInode {
+		t.Errorf("peerMap[server inode %d] = %d, want %d", serverInode, got, clientInode)
+	}
+}
+
 func TestFindGPGContext(t *testing.T) {
-	// findGPGContext scans /proc.  We cannot guarantee a GPG process is running,
-	// but we can verify it returns a string (possibly empty) without panicking.
+	// We cannot guarantee gpg-agent is running, but the function must not panic
+	// and must return something sensible (empty string when no gpg-agent).
 	result := findGPGContext()
-	// If the test binary itself matched a candidate name this would be non-empty,
-	// but "context.test" does not match any candidate — so we just check no panic.
 	_ = result
 }
 
 func TestFindGPGContext_ExcludesDaemons(t *testing.T) {
-	// Verify that gpgContextExcluded contains the expected daemon names.
 	for _, daemon := range []string{"gpg-agent", "scdaemon"} {
 		if !gpgContextExcluded[daemon] {
 			t.Errorf("expected %q to be in gpgContextExcluded", daemon)
-		}
-	}
-}
-
-func TestFindGPGContext_CandidateList(t *testing.T) {
-	// Verify that the candidate list contains the expected program names.
-	expected := []string{"gpg", "git", "ssh", "pass"}
-	for _, name := range expected {
-		found := false
-		for _, cand := range gpgContextCandidates {
-			if cand == name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected %q to be in gpgContextCandidates", name)
 		}
 	}
 }

--- a/detector/gpg.go
+++ b/detector/gpg.go
@@ -46,18 +46,45 @@ func WatchGPG(filesToWatch []string, requestGPGCheck chan string) {
 	}
 }
 
-// CheckGPGOnRequest checks whether YubiKey is actually waiting for a touch on a GPG request
-func CheckGPGOnRequest(requestGPGCheck chan string, notifiers *sync.Map, ctx *gpgme.Context) {
-	check := func(response chan error, ctx *gpgme.Context, t *time.Timer) {
-		err := ctx.AssuanSend("LEARN", nil, nil, func(status, args string) error {
-			log.Debugf("AssuanSend/status: %v, %v", status, args)
+// CheckGPGOnRequest checks whether YubiKey is actually waiting for a touch on a GPG request.
+// newCtx is called to create or recreate the GPG Assuan context; it is invoked again on
+// error to recover from a stale connection (e.g. after gpg-agent restarts).
+func CheckGPGOnRequest(requestGPGCheck chan string, notifiers *sync.Map, newCtx func() (*gpgme.Context, error)) {
+	ctx, err := newCtx()
+	if err != nil {
+		log.Errorf("Cannot create GPG Assuan context: %v", err)
+		return
+	}
 
+	reconnect := func() {
+		newCtx2, err := newCtx()
+		if err != nil {
+			log.Errorf("Failed to reconnect GPG context: %v", err)
+			return
+		}
+		ctx = newCtx2
+		log.Debug("GPG context reconnected successfully")
+	}
+
+	assuanLearn := func() error {
+		return ctx.AssuanSend("LEARN", nil, nil, func(status, args string) error {
+			log.Debugf("AssuanSend/status: %v, %v", status, args)
 			return nil
 		})
+	}
+
+	check := func(response chan error, t *time.Timer) {
+		err := assuanLearn()
+		if err != nil {
+			log.Debugf("GPG agent error: %v; reconnecting and retrying", err)
+			reconnect()
+			err = assuanLearn()
+		}
 		if !t.Stop() {
 			response <- err
 		}
 	}
+
 	for context := range requestGPGCheck {
 		resp := make(chan error)
 
@@ -77,6 +104,6 @@ func CheckGPGOnRequest(requestGPGCheck chan string, notifiers *sync.Map, ctx *gp
 		})
 
 		time.Sleep(200 * time.Millisecond) // wait for GPG to start talking with scdaemon
-		check(resp, ctx, t)
+		check(resp, t)
 	}
 }

--- a/detector/gpg.go
+++ b/detector/gpg.go
@@ -12,7 +12,7 @@ import (
 )
 
 // WatchGPG watches for hints that YubiKey is maybe waiting for a touch on a GPG request
-func WatchGPG(filesToWatch []string, requestGPGCheck chan bool) {
+func WatchGPG(filesToWatch []string, requestGPGCheck chan string) {
 	// No need for a buffered channel,
 	// we are interested only in the first event, it's ok to skip all subsequent ones
 	events := make(chan notify.EventInfo)
@@ -34,7 +34,7 @@ func WatchGPG(filesToWatch []string, requestGPGCheck chan bool) {
 		switch event.Event() {
 		case notify.InOpen:
 			select {
-			case requestGPGCheck <- true:
+			case requestGPGCheck <- findGPGContext():
 			default:
 			}
 		default:
@@ -47,7 +47,7 @@ func WatchGPG(filesToWatch []string, requestGPGCheck chan bool) {
 }
 
 // CheckGPGOnRequest checks whether YubiKey is actually waiting for a touch on a GPG request
-func CheckGPGOnRequest(requestGPGCheck chan bool, notifiers *sync.Map, ctx *gpgme.Context) {
+func CheckGPGOnRequest(requestGPGCheck chan string, notifiers *sync.Map, ctx *gpgme.Context) {
 	check := func(response chan error, ctx *gpgme.Context, t *time.Timer) {
 		err := ctx.AssuanSend("LEARN", nil, nil, func(status, args string) error {
 			log.Debugf("AssuanSend/status: %v, %v", status, args)
@@ -58,12 +58,12 @@ func CheckGPGOnRequest(requestGPGCheck chan bool, notifiers *sync.Map, ctx *gpgm
 			response <- err
 		}
 	}
-	for range requestGPGCheck {
+	for context := range requestGPGCheck {
 		resp := make(chan error)
 
 		t := time.AfterFunc(400*time.Millisecond, func() {
 			notifiers.Range(func(_, v interface{}) bool {
-				v.(chan notifier.Message) <- notifier.GPG_ON
+				v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: notifier.GPG_ON, Context: context}
 				return true
 			})
 			err := <-resp
@@ -71,7 +71,7 @@ func CheckGPGOnRequest(requestGPGCheck chan bool, notifiers *sync.Map, ctx *gpgm
 				log.Errorf("Agent returned an error: %v", err)
 			}
 			notifiers.Range(func(_, v interface{}) bool {
-				v.(chan notifier.Message) <- notifier.GPG_OFF
+				v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: notifier.GPG_OFF}
 				return true
 			})
 		})

--- a/detector/gpg_test.go
+++ b/detector/gpg_test.go
@@ -1,0 +1,27 @@
+package detector
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/proglottis/gpgme"
+)
+
+func TestCheckGPGOnRequest_FactoryErrorExitsCleanly(t *testing.T) {
+	ch := make(chan string)
+	close(ch) // No requests; loop exits immediately after factory fails.
+
+	callCount := 0
+	factory := func() (*gpgme.Context, error) {
+		callCount++
+		return nil, fmt.Errorf("simulated gpg-agent unavailable")
+	}
+
+	var notifiers sync.Map
+	CheckGPGOnRequest(ch, &notifiers, factory)
+
+	if callCount != 1 {
+		t.Errorf("factory called %d times, want 1", callCount)
+	}
+}

--- a/detector/hmac.go
+++ b/detector/hmac.go
@@ -49,7 +49,7 @@ func WatchHMAC(notifiers *sync.Map) {
 				newMessage := notifier.HMAC_OFF
 				if lastMessage != newMessage {
 					notifiers.Range(func(_, v interface{}) bool {
-						v.(chan notifier.Message) <- newMessage
+						v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: newMessage}
 						return true
 					})
 				}
@@ -71,7 +71,7 @@ func WatchHMAC(notifiers *sync.Map) {
 
 					if lastMessage != newMessage {
 						notifiers.Range(func(_, v interface{}) bool {
-							v.(chan notifier.Message) <- newMessage
+							v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: newMessage}
 							return true
 						})
 					}

--- a/detector/ssh.go
+++ b/detector/ssh.go
@@ -12,7 +12,7 @@ import (
 )
 
 // WatchSSH watches for hints that YubiKey is maybe waiting for a touch on a SSH auth request
-func WatchSSH(requestGPGCheck chan bool, exits *sync.Map) {
+func WatchSSH(requestGPGCheck chan string, exits *sync.Map) {
 	socketFile := os.Getenv("SSH_AUTH_SOCK")
 
 	if socketFile == "" {
@@ -94,12 +94,15 @@ func WatchSSH(requestGPGCheck chan bool, exits *sync.Map) {
 			return
 		}
 
-		go proxyUnixSocket(proxyConnection, originalConnection, requestGPGCheck)
-		go proxyUnixSocket(originalConnection, proxyConnection, requestGPGCheck)
+		// Identify the local process that connected to the SSH agent proxy.
+		peerContext := getPeerProcessCmdline(proxyConnection)
+
+		go proxyUnixSocket(proxyConnection, originalConnection, requestGPGCheck, peerContext)
+		go proxyUnixSocket(originalConnection, proxyConnection, requestGPGCheck, "")
 	}
 }
 
-func proxyUnixSocket(reader net.Conn, writer net.Conn, requestGPGCheck chan bool) {
+func proxyUnixSocket(reader net.Conn, writer net.Conn, requestGPGCheck chan string, context string) {
 	defer (func() {
 		reader.Close()
 		writer.Close()
@@ -118,7 +121,7 @@ func proxyUnixSocket(reader net.Conn, writer net.Conn, requestGPGCheck chan bool
 		}
 
 		select {
-		case requestGPGCheck <- true:
+		case requestGPGCheck <- context:
 		default:
 		}
 	}

--- a/detector/ssh.go
+++ b/detector/ssh.go
@@ -96,6 +96,7 @@ func WatchSSH(requestGPGCheck chan string, exits *sync.Map) {
 
 		// Identify the local process that connected to the SSH agent proxy.
 		peerContext := getPeerProcessCmdline(proxyConnection)
+		log.Debugf("SSH proxy: accepted connection, peerContext=%q", peerContext)
 
 		go proxyUnixSocket(proxyConnection, originalConnection, requestGPGCheck, peerContext)
 		go proxyUnixSocket(originalConnection, proxyConnection, requestGPGCheck, "")

--- a/detector/u2f.go
+++ b/detector/u2f.go
@@ -145,7 +145,7 @@ func runU2FWatcher(devicePath string, notifiers *sync.Map) {
 			}
 			if lastMessage != notifier.U2F_OFF {
 				notifiers.Range(func(_, v interface{}) bool {
-					v.(chan notifier.Message) <- notifier.U2F_OFF
+					v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: notifier.U2F_OFF}
 					return true
 				})
 			}
@@ -171,7 +171,7 @@ func runU2FWatcher(devicePath string, notifiers *sync.Map) {
 			// Signify U2F_ON if this is the first time we receive it
 			if lastMessage != notifier.U2F_ON {
 				notifiers.Range(func(_, v interface{}) bool {
-					v.(chan notifier.Message) <- notifier.U2F_ON
+					v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: notifier.U2F_ON}
 					return true
 				})
 				lastMessage = notifier.U2F_ON
@@ -185,7 +185,7 @@ func runU2FWatcher(devicePath string, notifiers *sync.Map) {
 		u2fOffTimer = time.AfterFunc(u2fOffTimerDuration, func() {
 			if lastMessage != notifier.U2F_OFF {
 				notifiers.Range(func(_, v interface{}) bool {
-					v.(chan notifier.Message) <- notifier.U2F_OFF
+					v.(chan notifier.TouchEvent) <- notifier.TouchEvent{Type: notifier.U2F_OFF}
 					return true
 				})
 				lastMessage = notifier.U2F_OFF

--- a/main.go
+++ b/main.go
@@ -87,14 +87,19 @@ func main() {
 }
 
 func initGPGBasedDetectors(notifiers, exits *sync.Map) {
-	ctx, err := gpgme.New()
-	if err != nil {
-		log.Debugf("Cannot initialize GPG context: %v. Disabling GPG and SSH watchers.", err)
-		return
+	newAssuanCtx := func() (*gpgme.Context, error) {
+		ctx, err := gpgme.New()
+		if err != nil {
+			return nil, fmt.Errorf("cannot initialize GPG context: %w", err)
+		}
+		if err := ctx.SetProtocol(gpgme.ProtocolAssuan); err != nil {
+			return nil, fmt.Errorf("cannot initialize Assuan IPC: %w", err)
+		}
+		return ctx, nil
 	}
 
-	if ctx.SetProtocol(gpgme.ProtocolAssuan) != nil {
-		log.Debugf("Cannot initialize Assuan IPC: %v. Disabling GPG and SSH watchers.", err)
+	if _, err := newAssuanCtx(); err != nil {
+		log.Debugf("%v. Disabling GPG and SSH watchers.", err)
 		return
 	}
 
@@ -116,7 +121,7 @@ func initGPGBasedDetectors(notifiers, exits *sync.Map) {
 	}
 
 	requestGPGCheck := make(chan string)
-	go detector.CheckGPGOnRequest(requestGPGCheck, notifiers, ctx)
+	go detector.CheckGPGOnRequest(requestGPGCheck, notifiers, newAssuanCtx)
 	go detector.WatchGPG(filesToWatch, requestGPGCheck)
 	go detector.WatchSSH(requestGPGCheck, exits)
 }

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func initGPGBasedDetectors(notifiers, exits *sync.Map) {
 		return
 	}
 
-	requestGPGCheck := make(chan bool)
+	requestGPGCheck := make(chan string)
 	go detector.CheckGPGOnRequest(requestGPGCheck, notifiers, ctx)
 	go detector.WatchGPG(filesToWatch, requestGPGCheck)
 	go detector.WatchSSH(requestGPGCheck, exits)

--- a/notifier/dbus.go
+++ b/notifier/dbus.go
@@ -118,14 +118,14 @@ func SetupDbusNotifier(notifiers *sync.Map) {
 	}
 	log.Debug("Connected to dbus session interface ", DBUS_IFACE)
 
-	touch := make(chan Message, 10)
+	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/dbus", touch)
 
 	for {
-		message := <-touch
-		err := props.Set(DBUS_IFACE, messagePropMap[message], messageValueMap[message])
+		event := <-touch
+		err := props.Set(DBUS_IFACE, messagePropMap[event.Type], messageValueMap[event.Type])
 		if err != nil {
-			log.Warn("dbus failed to update property ", messagePropMap[message], ", ", err)
+			log.Warn("dbus failed to update property ", messagePropMap[event.Type], ", ", err)
 		}
 	}
 }

--- a/notifier/debug.go
+++ b/notifier/debug.go
@@ -8,11 +8,15 @@ import (
 
 // SetupDebugNotifier configures a notifier to log all touch events
 func SetupDebugNotifier(notifiers *sync.Map) {
-	touch := make(chan Message, 10)
+	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/debug", touch)
 
 	for {
-		value := <-touch
-		log.Debug("[notifiers/debug] ", value)
+		event := <-touch
+		if event.Context != "" {
+			log.Debug("[notifiers/debug] ", event.Type, " (", event.Context, ")")
+		} else {
+			log.Debug("[notifiers/debug] ", event.Type)
+		}
 	}
 }

--- a/notifier/libnotify.go
+++ b/notifier/libnotify.go
@@ -12,7 +12,7 @@ import (
 
 // SetupLibnotifyNotifier configures a notifier to show all touch requests with libnotify
 func SetupLibnotifyNotifier(notifiers *sync.Map) {
-	touch := make(chan Message, 10)
+	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/libnotify", touch)
 
 	notification := notify.Notification{
@@ -33,12 +33,18 @@ func SetupLibnotifyNotifier(notifiers *sync.Map) {
 	activeTouchWaits := 0
 
 	for {
-		value := <-touch
-		if value == GPG_ON || value == U2F_ON || value == HMAC_ON {
+		event := <-touch
+		if event.Type == GPG_ON || event.Type == U2F_ON || event.Type == HMAC_ON {
 			activeTouchWaits++
+			if event.Context != "" {
+				notification.Body = event.Context
+			}
 		}
-		if value == GPG_OFF || value == U2F_OFF || value == HMAC_OFF {
+		if event.Type == GPG_OFF || event.Type == U2F_OFF || event.Type == HMAC_OFF {
 			activeTouchWaits--
+		}
+		if activeTouchWaits <= 0 {
+			notification.Body = ""
 		}
 		if activeTouchWaits > 0 {
 			id, err := notifier.SendNotification(notification)

--- a/notifier/libnotify.go
+++ b/notifier/libnotify.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/esiqveland/notify"
 	"github.com/godbus/dbus/v5"
@@ -10,17 +11,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// postTouchDisplay is how long the "YubiKey was in use" banner stays visible
+// after the operation finishes, so the user has time to read the context.
+const postTouchDisplay = 5 * time.Second
+
 // SetupLibnotifyNotifier configures a notifier to show all touch requests with libnotify
 func SetupLibnotifyNotifier(notifiers *sync.Map) {
 	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/libnotify", touch)
 
 	notification := notify.Notification{
-		AppName: "yubikey-touch-detector",
-		AppIcon: "yubikey-touch-detector",
-		Summary: "YubiKey is waiting for a touch",
+		AppName:       "yubikey-touch-detector",
+		AppIcon:       "yubikey-touch-detector",
+		Summary:       "YubiKey is waiting for a touch",
+		ExpireTimeout: notify.ExpireTimeoutNever,
 	}
-	notification.AddHint(notify.Hint{ID: "transient", Variant: dbus.MakeVariant(true)})
 
 	conn, notifier, err := connectDBus(&notification.ReplacesID)
 	if err != nil {
@@ -32,8 +37,30 @@ func SetupLibnotifyNotifier(notifiers *sync.Map) {
 
 	activeTouchWaits := 0
 
+	sendNotification := func() {
+		id, err := notifier.SendNotification(notification)
+		if err != nil {
+			log.Error("Cannot show notification (will reconnect to DBUS): ", err)
+			notifier.Close()
+			conn.Close()
+			conn, notifier, err = connectDBus(&notification.ReplacesID)
+			if err != nil {
+				log.Error("Failed to reconnect: ", err)
+				return
+			}
+			id, err = notifier.SendNotification(notification)
+			if err != nil {
+				log.Error("Cannot show notification after reconnect: ", err)
+				return
+			}
+		}
+		atomic.CompareAndSwapUint32(&notification.ReplacesID, 0, id)
+	}
+
 	for {
 		event := <-touch
+		prevActiveTouchWaits := activeTouchWaits
+
 		if event.Type == GPG_ON || event.Type == U2F_ON || event.Type == HMAC_ON {
 			activeTouchWaits++
 			if event.Context != "" {
@@ -41,39 +68,22 @@ func SetupLibnotifyNotifier(notifiers *sync.Map) {
 			}
 		}
 		if event.Type == GPG_OFF || event.Type == U2F_OFF || event.Type == HMAC_OFF {
-			activeTouchWaits--
+			if activeTouchWaits > 0 {
+				activeTouchWaits--
+			}
 		}
-		if activeTouchWaits <= 0 {
-			notification.Body = ""
-		}
+
 		if activeTouchWaits > 0 {
-			id, err := notifier.SendNotification(notification)
-			if err != nil {
-				log.Error("Cannot show notification (will reconnect to DBUS): ", err)
-				notifier.Close()
-				conn.Close()
-				conn, notifier, err = connectDBus(&notification.ReplacesID)
-				if err != nil {
-					log.Error("Failed to reconnect: ", err)
-					continue
-				}
-				id, err = notifier.SendNotification(notification)
-				if err != nil {
-					log.Error("Cannot show notification after reconnect: ", err)
-					continue
-				}
-			}
-			atomic.CompareAndSwapUint32(&notification.ReplacesID, 0, id)
-		} else if id := atomic.LoadUint32(&notification.ReplacesID); id != 0 {
-			if _, err := notifier.CloseNotification(id); err != nil {
-				log.Error("Cannot close notification (will reconnect to DBUS): ", err)
-				notifier.Close()
-				conn.Close()
-				conn, notifier, err = connectDBus(&notification.ReplacesID)
-				if err != nil {
-					log.Error("Failed to reconnect: ", err)
-				}
-			}
+			notification.Summary = "YubiKey is waiting for a touch"
+			notification.ExpireTimeout = notify.ExpireTimeoutNever
+			sendNotification()
+		} else if prevActiveTouchWaits > 0 {
+			// Transition from active to idle: keep notification briefly so the
+			// user can see what operation just completed.
+			notification.Summary = "YubiKey was in use"
+			notification.ExpireTimeout = postTouchDisplay
+			sendNotification()
+			notification.Body = ""
 		}
 	}
 }

--- a/notifier/message.go
+++ b/notifier/message.go
@@ -11,3 +11,10 @@ const (
 	HMAC_ON  Message = "MAC_1"
 	HMAC_OFF Message = "MAC_0"
 )
+
+// TouchEvent carries a touch notification together with optional human-readable
+// context describing the process that triggered the request.
+type TouchEvent struct {
+	Type    Message
+	Context string
+}

--- a/notifier/stdout.go
+++ b/notifier/stdout.go
@@ -7,11 +7,11 @@ import (
 
 // SetupStdoutNotifier configures a notifier to log to stdout
 func SetupStdoutNotifier(notifiers *sync.Map) {
-	touch := make(chan Message, 10)
+	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/stdout", touch)
 
 	for {
-		value := <-touch
-		fmt.Println(value)
+		event := <-touch
+		fmt.Println(event.Type)
 	}
 }

--- a/notifier/unix_socket.go
+++ b/notifier/unix_socket.go
@@ -63,17 +63,19 @@ func SetupUnixSocketNotifier(notifiers *sync.Map, exits *sync.Map) {
 		exit <- true
 	}()
 
-	touch := make(chan Message, 10)
+	touch := make(chan TouchEvent, 10)
 	notifiers.Store("notifier/unix_socket", touch)
 
 	touchListeners := make(map[*net.Conn]chan []byte)
 	touchListenersMutex := sync.RWMutex{}
 	go func() {
 		for {
-			value := <-touch
+			event := <-touch
+			// Send only the 5-byte Type string to preserve the documented wire protocol.
+			payload := []byte(event.Type)
 			touchListenersMutex.RLock()
 			for _, listener := range touchListeners {
-				listener <- []byte(value)
+				listener <- payload
 			}
 			touchListenersMutex.RUnlock()
 		}


### PR DESCRIPTION
Ref issue #81, I consider it very important to know *why* I should press the yubikey.  Pressing the yubi key without knowing why it's needed to press it is like signing a paper without even reading the title of the paper.

Status 2026-05-26: This is mostly "vibed up", with a minimum of human review.  It works specifically only together with gpg-agent.  Getting this to work with PIV etc is notoriously more difficult.  I'm testing it, and have found some bugs that should be ironed out.